### PR TITLE
Use full pixel count for sequence length

### DIFF
--- a/generate_data/dynamic_resolution_trainer.py
+++ b/generate_data/dynamic_resolution_trainer.py
@@ -761,7 +761,7 @@ def load_config_from_yaml(config_path: str) -> Dict[str, Any]:
             
             config['model']['input_dim'] = input_h * input_w
             config['model']['output_dim'] = output_h * output_w
-            config['model']['seq_len'] = int(np.sqrt(input_h * input_w))
+            config['model']['seq_len'] = input_h * input_w
     
     return config
 

--- a/generate_data/dynamic_resolution_trainer_backup.py
+++ b/generate_data/dynamic_resolution_trainer_backup.py
@@ -720,7 +720,7 @@ def load_config_from_yaml(config_path: str) -> Dict[str, Any]:
             
             config['model']['input_dim'] = input_h * input_w
             config['model']['output_dim'] = output_h * output_w
-            config['model']['seq_len'] = int(np.sqrt(input_h * input_w))
+            config['model']['seq_len'] = input_h * input_w
     
     return config
 


### PR DESCRIPTION
## Summary
- Set `seq_len` to the product of input height and width when loading YAML configs in dynamic resolution trainer
- Apply the same `seq_len` calculation in the backup trainer for consistency

## Testing
- `pytest` *(fails: SystemExit in test_qt_fix.py)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7a7f6fc83278ae978c0a0fd335b