### PR TITLE
Fix lazy-loading original shape dimensions

### DIFF
--- a/generate_data/dynamic_resolution_trainer.py
+++ b/generate_data/dynamic_resolution_trainer.py
@@ -514,7 +514,7 @@ class DynamicResolutionDataset(torch.utils.data.Dataset):
             original_sample = self.original_data[idx:idx+1]  # 保持3D形状
         
         # 生成输入数据（裁剪到输入分辨率） - CPU计算
-        original_shape = self.data_shape if self.lazy_loading else self.original_data.shape[1:]
+        original_shape = self.data_shape[1:] if self.lazy_loading else self.original_data.shape[1:]
         if self.input_resolution == original_shape:
             input_data = original_sample[0]
         else:


### PR DESCRIPTION
## Summary
- Ensure DynamicResolutionDataset uses (height, width) when lazy loading by excluding sample axis from data_shape

## Testing
- `python -m py_compile generate_data/dynamic_resolution_trainer.py`
- Attempted to run lazy-loading dataset test; failed to import `h5py` (`ModuleNotFoundError`), and both `pip install h5py` and `apt-get update` failed due to 403 Forbidden


------
https://chatgpt.com/codex/tasks/task_e_6895e7a94bbc8327961319c8f9e09fdb